### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Intelligent Chinese Chess
 
 >Course project for Data Structure and Algorithm. Project2.
 
-###Overview
+### Overview
 A Chinese Chess game implemented with artificial intelligence, rendered in Java 2D. Supports human-computer competition.
 
 The project is written in Java. You are supposed to run ‘ChineseChess.java’ in Intellij IDEA, instead of Eclipse. The project is open sourced on [Github](https://github.com/geeeeeeeeek/IntelligentChineseChessSystem/).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
